### PR TITLE
tests: use EnvClient for testing with an existing cluster

### DIFF
--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -79,8 +79,12 @@ func TestNetworkExternalLb(t *testing.T) {
 	if e := os.Getenv("DOCKER_E2E_ENDPOINT"); e != "" {
 		endpoint = e
 	} else {
+		if os.Getenv("DOCKER_HOST") != "" {
+			t.Log("warning: DOCKER_HOST is set but DOCKER_E2E_ENDPOINT is not set")
+		}
 		endpoint = "127.0.0.1"
 	}
+	t.Logf("Using %s as the endpoint. Note that the port 8080 needs to be accessible from this host.", endpoint)
 
 	// first we need a function to poll containers, and let it run
 	go func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -16,12 +16,11 @@ import (
 const E2EServiceLabel = "e2etesting"
 
 func GetClient() (*client.Client, error) {
-	// TODO(dperny): Determine if we need to pass any headers stuff
-	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient("unix:///var/run/docker.sock", "v1.22", nil, defaultHeaders)
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, err
 	}
+	cli.UpdateClientVersion("v1.22")
 	return cli, nil
 }
 


### PR DESCRIPTION
How to test:

```
$ docker-machine create -d some-driver dm01
$ eval $(docker-machine env dm01)
$ go test -v ./tests
```

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
