### PR TITLE
fixed testkit to use newest d4aws, added attach cmd

### DIFF
--- a/testkit/cmd/attach.go
+++ b/testkit/cmd/attach.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/signal"
+	"os/user"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/docker/docker-e2e/testkit/environment"
+	"github.com/spf13/cobra"
+)
+
+var attachCmd = &cobra.Command{
+	Use:   "attach <env>",
+	Short: "attach a local socket to the docker socket on a remote host",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return errors.New("Environment missing")
+		}
+
+		env := environment.New(args[0], newSession())
+		host, err := env.SSHEndpoint()
+		if err != nil {
+			return err
+		}
+
+		var socket string
+		if cmd.Flags().Changed("socket") {
+			socket, err = cmd.Flags().GetString("socket")
+			if err != nil {
+				return err
+			}
+		} else {
+			dir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			socket = dir + "/docker.sock"
+		}
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			return err
+		}
+		err = openTunnel(host, socket, verbose)
+		return err
+	},
+}
+
+// openTunnel opens a tunnel over ssh from a socket in the local directory to
+// the docker socket on the cluster.
+func openTunnel(host, socket string, verbose bool) error {
+	fmt.Printf("opening tunnel to %v\n", host)
+	// set identity file
+	// TODO(dperny) this is copied out of loadSSHKeys. possible to DRY?
+	usr, err := user.Current()
+	if err != nil {
+		return err
+	}
+	keyDir := filepath.Join(usr.HomeDir, "/.ssh/")
+	keys, err := ioutil.ReadDir(keyDir)
+	if err != nil {
+		return err
+	}
+
+	keyfiles := []string{}
+	for _, f := range keys {
+		keyPath := filepath.Join(keyDir, f.Name())
+		key, err := ioutil.ReadFile(keyPath)
+		if err != nil {
+			continue
+		}
+		// we do ParsePrivateKey to see if the key is in fact a key. if it's
+		// not, this will return an error.
+		_, err = ssh.ParsePrivateKey(key)
+		if err != nil {
+			continue
+		}
+		keyfiles = append(keyfiles, keyPath)
+	}
+
+	// start building the command
+	opts := make([]string, 0, 4)
+	// no terminal
+	opts = append(opts, "-nNT")
+	if verbose {
+		opts = append(opts, "-v")
+	}
+	// identity files
+	for _, key := range keyfiles {
+		opts = append(opts, "-i"+key)
+	}
+
+	// socket location
+	opts = append(opts, "-L"+socket+":/var/run/docker.sock")
+	// host
+	opts = append(opts, "docker@"+host)
+
+	cmd := exec.Command("ssh", opts...)
+	// wire up the command outputs to our ouputs
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// set up channel for stop signals
+	signals := make(chan os.Signal, 1)
+	// register for SIGINT and SIGTERM, this is what we will die on
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	// set up channel for command dying
+	finished := make(chan struct{})
+
+	// start the command
+	cmd.Start()
+
+	// wait for the command to terminate itself
+	go func() {
+		cmd.Wait()
+		// when it has, signal the wait that we're done
+		close(finished)
+	}()
+
+	// tell the user how we're connecting
+	fmt.Printf("remote docker server is listening locally at %v\n", socket)
+	// TODO(dperny) print how to do configure docker daemon for this
+
+	// wait for a signals or termination
+	select {
+	case sig := <-signals:
+		// pass it down to the ssh command
+		cmd.Process.Signal(sig)
+	case <-finished:
+	}
+
+	err = os.Remove(socket)
+	return err
+}
+
+func init() {
+	attachCmd.Flags().BoolP("verbose", "v", false, "start ssh in verbose mode (for debugging)")
+	attachCmd.Flags().String("socket", "", "the location to open the docker socket")
+}

--- a/testkit/cmd/root.go
+++ b/testkit/cmd/root.go
@@ -51,6 +51,7 @@ var mainCmd = &cobra.Command{
 
 func init() {
 	mainCmd.AddCommand(
+		attachCmd,
 		purgeCmd,
 		createCmd,
 		execCmd,

--- a/testkit/environment/environment.go
+++ b/testkit/environment/environment.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -15,13 +14,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 )
 
 func List(sess *session.Session) ([]*cloudformation.Stack, error) {
 	cf := cloudformation.New(sess)
 
-	stacks := make([]*cloudformation.Stack, 0)
+	stacks := []*cloudformation.Stack{}
 
 	input := &cloudformation.DescribeStacksInput{}
 	for {
@@ -79,16 +79,18 @@ func Purge(sess *session.Session, ttl time.Duration) error {
 // Environment represents a testing cluster, including a CloudFormation stack
 // and SSH client
 type Environment struct {
-	id     string
-	cf     *cloudformation.CloudFormation
-	client *ssh.Client
+	id      string
+	cf      *cloudformation.CloudFormation
+	session *session.Session
+	client  *ssh.Client
 }
 
 // New returns a new environment
 func New(id string, sess *session.Session) *Environment {
 	return &Environment{
-		id: id,
-		cf: cloudformation.New(sess),
+		id:      id,
+		cf:      cloudformation.New(sess),
+		session: sess,
 	}
 }
 
@@ -100,27 +102,93 @@ func (c *Environment) Destroy() error {
 	return err
 }
 
-// SSHEndpoint returns the ssh endpoint of the CloudFormation stack
+// SSHEndpoint returns an ssh endpoint of the CloudFormation stack
 func (c *Environment) SSHEndpoint() (string, error) {
+	// get a list of all of the manager ips
+	ips, err := c.ManagerIPs()
+	if err != nil {
+		return "", err
+	}
+
+	// we should never get 0 ip addresses back from ManagerIPs without error,
+	// but just in case, we should check to avoid segfaulting
+	if len(ips) == 0 {
+		return "", errors.New("no ip addresses found")
+	}
+
+	// return the first endpoint. it's as good as any other
+	// TODO(dperny) should we append the port? i think probably not
+	return ips[0], nil
+}
+
+// ManagerIPs returns a list of IP addresses of manager nodes
+func (c *Environment) ManagerIPs() ([]string, error) {
 	output, err := c.cf.DescribeStacks(&cloudformation.DescribeStacksInput{
 		StackName: aws.String(c.id),
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(output.Stacks) != 1 {
-		return "", errors.New("stack not found")
+		return nil, errors.New("stack not found")
+	}
+	stack := output.Stacks[0]
+
+	// create a new EC2 client so we can list EC2 instances
+	ec2client := ec2.New(c.session)
+
+	// use the swarm info as filters
+	//   swarm-stack-id: from describe stack
+	//   swarm-node-type: manager
+	// if the above API ever changes (lol) we can use these two tags instead:
+	//   aws:cloudformation:stack-id: from describe stack
+	//   aws:cloudformation:logical-id: ManagerAsg
+	input := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("tag:swarm-stack-id"),
+				Values: []*string{stack.StackId},
+			},
+			&ec2.Filter{
+				Name:   aws.String("tag:swarm-node-type"),
+				Values: []*string{aws.String("manager")},
+			},
+		},
 	}
 
-	for _, o := range output.Stacks[0].Outputs {
-		if *o.OutputKey == "SSH" {
-			// Formatted as "ssh docker@docker-e2e-20160928-ELB-SSH-1653593963.us-east-1.elb.amazonaws.com"
-			endpoint := *o.OutputValue
-			return strings.SplitN(endpoint, "@", 2)[1] + ":22", nil
+	// slice of ip addresses. we can expect at least 3, probably, so 3 is a
+	// good starting value
+	ips := []string{}
+	// loop until we have no next page
+	for {
+		// do the api call, check for errors. duh.
+		resp, err := ec2client.DescribeInstances(input)
+		if err != nil {
+			return nil, err
 		}
+
+		// instances may or may not belong to the same reservation. we don't
+		// care, and we must iterate through both together as a rule
+		for _, res := range resp.Reservations {
+			for _, instance := range res.Instances {
+				ips = append(ips, *instance.PublicIpAddress)
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		// set the next token, in case our response has multiple pages
+		input.NextToken = resp.NextToken
 	}
 
-	return "", errors.New("unable to retrieve SSH endpoint")
+	// make sure we actually have ip addresses, so that we don't just return
+	// emptystring and no error.
+	if len(ips) == 0 {
+		return nil, errors.New("unable to retrieve SSH endpoint, found no managers")
+	}
+
+	return ips, nil
 }
 
 func (c *Environment) loadSSHKeys() (ssh.AuthMethod, error) {
@@ -154,10 +222,11 @@ func (c *Environment) loadSSHKeys() (ssh.AuthMethod, error) {
 }
 
 func (c *Environment) Connect() error {
-	endpoint, err := c.sshEndpoint()
+	endpoint, err := c.SSHEndpoint()
 	if err != nil {
 		return err
 	}
+	endpoint = endpoint + ":22"
 
 	auth, err := c.loadSSHKeys()
 	if err != nil {


### PR DESCRIPTION
Docker for AWS changed the way they handle SSH endpoints, and this update fixes it. In addition, a `testkit attach` command has been added which opens a local docker socket that is forwarded to the remote.

/cc @aluzzardi 

Signed-off-by: Drew Erny <drew.erny@docker.com>