### PR TITLE
Update tests 1.13

### DIFF
--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -24,7 +24,7 @@ func TestServicesList(t *testing.T) {
 	assert.NoError(t, err, "Client creation failed")
 
 	// list all services with the "TestServiceList" label
-	opts := types.ServiceListOptions{Filter: GetTestFilter("TestServiceList")}
+	opts := types.ServiceListOptions{Filters: GetTestFilter("TestServiceList")}
 	services, err := cli.ServiceList(context.Background(), opts)
 	// there shouldn't be any services with that label
 	assert.NoError(t, err, "error listing service")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -28,7 +28,7 @@ func CleanTestServices(ctx context.Context, cli *client.Client, labels ...string
 	// create a new filter for our test label
 	f := GetTestFilter(labels...)
 	opts := types.ServiceListOptions{
-		Filter: f,
+		Filters: f,
 	}
 	// get the services with that label
 	services, err := cli.ServiceList(ctx, opts)
@@ -122,7 +122,7 @@ func GetServiceTasks(ctx context.Context, cli *client.Client, serviceID string) 
 	filterArgs.Add("desired-state", "ready")
 	// on the service we're requesting
 	filterArgs.Add("service", serviceID)
-	return cli.TaskList(ctx, types.TaskListOptions{Filter: filterArgs})
+	return cli.TaskList(ctx, types.TaskListOptions{Filters: filterArgs})
 }
 
 // GetTestFilter creates a default filter for labels
@@ -164,11 +164,20 @@ func ScaleCheck(serviceID string, cli *client.Client) func(context.Context, int)
 	}
 }
 
-// ServiceScale scales a service to the provided number
-/*
-func ServiceScale(ctx context.Context, cli *client.Client, serviceID string, replicas uint64) (serviceID, error) {
-	service, _, err = cli.ServiceInspectWithRaw(ctx, serviceID)
-	spec := service.Spec
-	spec.Mode.Replicated.Replicas = &replicas
+// GetNodeIps returns a list of all node IP addresses in the cluster
+func GetNodeIps(cli *client.Client) ([]string, error) {
+	nodes, err := cli.NodeList(context.TODO(), types.NodeListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// standard cluster is like 3 managers 5 workers, so 8 is a good start
+	ips := make([]string, 0, 8)
+	for _, node := range nodes {
+		ip := node.Status.Addr
+		if ip == "" {
+			return nil, errors.New("some node didn't have an associated IP")
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
 }
-*/

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -16,9 +16,7 @@ import (
 const E2EServiceLabel = "e2etesting"
 
 func GetClient() (*client.Client, error) {
-	// TODO(dperny): Determine if we need to pass any headers stuff
-	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient("unix:///var/run/docker.sock", "v1.22", nil, defaultHeaders)
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The tests broke because of changes to the 1.13 API. This brings them back in line with docker master, and also fixes some other warts.