### PR TITLE
Add test documentation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# Considerations when writing tests
+
+## "Namespacing"
+
+When running most tests, we (in general) want the tests to be contained to,
+themselves, which is tricky when our tests by their nature must modify the 
+global state of the cluster. Because Swarmkit lacks native namespacing 
+capabilities, in the tests we instead hack a sort of poor man's namespacing 
+using UUIDs, name mangling, and labels. This usually doesn't affect the 
+behavior of the tests, but test writers should be aware of this so that their 
+tests don't become victim of a leaky abstraction.
+
+On test run start, a UUID is generated in `main_test.go`. This UUID is returned
+by the `UUID` function, and is used whenever some object needs to be 
+identified. Only objects (services etc.) that belong to this test will have 
+this UUID, so it can reliably be used to differentiate this test's objects from
+those that may have been generatd by another test.
+
+The functions in `utils.go` do most of the heavy lifting. When you create a 
+service spec with `CannedServiceSpec`, the name of the function is mangled to 
+add the UUID to the end. The original unmangled name is stored unadorned as a
+label. In addition, a `uuid` label is added, with the value set to the UUID. As
+as consequence of the name mangling, the name should not be used as an 
+identifier for the service; its final form is human readable for debugging 
+purposes but otherwise should be considered an implementation detail. If you 
+cannot or do not wish to use the service ID returned on creation, you should 
+filter service by name and uuid labels.

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -32,7 +32,6 @@ func TestNetworkExternalLb(t *testing.T) {
 	assert.NoError(t, err, "Client creation failed")
 
 	replicas := 3
-	// pass literal 3 so we don't have to cast
 	spec := CannedServiceSpec(name, uint64(replicas))
 	// use nginx
 	spec.TaskTemplate.ContainerSpec.Image = "dperny/docker-sample-nginx"

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -27,28 +27,68 @@ func TestServicesList(t *testing.T) {
 	assert.Empty(t, services)
 }
 
+// TestServicesCreate is the prototypical test. it should remain well-
+// documented and serve as the starting point for any new developer that wants
+// to write an e2e test. It tests that a service is successfully created.
 func TestServicesCreate(t *testing.T) {
+	// if your test can at all be run in parallel, do so.
 	t.Parallel()
-	// label name for cleanup later
+
+	// Create a name to use for this test. It will be passed as the name for
+	// most operations. This should be done even if you're creating multiple
+	// services; you can pass this name as a label later, which aids cleanup
 	name := "TestServicesCreate"
+
+	// Create a context for the test. This test should complete in under a
+	// minute. If this context lapses, all of the API calls will just quick
+	// return, saving time. This should also be used as the parent context for
+	// any subcontexts you create.
 	testContext, _ := context.WithTimeout(context.Background(), time.Minute)
 
+	// Use the same client for the whole test. Verify that your client has been
+	// created properly.
 	cli, err := GetClient()
-
 	assert.NoError(t, err, "Client creation failed")
-	// create a spec for a task named TestServicesCreate labeled the same, with 3 replicas
+
+	// Create a service spec to use. Your service specs should always be
+	// created with CannedServiceSpec. This function gives you a service spec
+	// with sensible default fields, as well as labels that assist in cleaning
+	// up. In addition, CannedServiceSpec mangles the name and adds the uuid
+	// label that we rely on to isolate this particular instance of the tests
+	// from any other instance that may be running
 	serviceSpec := CannedServiceSpec(name, 3)
 
-	// first, verify that the server responds as expected
+	// Now, do an API call. Pass testContext, which will take care of the
+	// timeout for us.
 	resp, err := cli.ServiceCreate(testContext, serviceSpec, types.ServiceCreateOptions{})
+	// Always make sure that the call completed as expected: no errors, non-nil
+	// response, and non-zero ID.
 	assert.NoError(t, err, "Error creating service")
 	assert.NotNil(t, resp, "Resp is nil for some reason")
 	assert.NotZero(t, resp.ID, "response ID shouldn't be zero")
 
-	// now make sure we can call back and get the service
+	// Take the service ID. You should ALWAYS refer to services internally by
+	// their ID and not by their name or any other features. Names are mangled,
+	// labels may be changed, and any other number of identifiers could be
+	// munged under the hood to facilitate "namespacing" the test, so the
+	// service ID should be the sole point of reference for a particular
+	// service whenever possible.
+	serviceID := resp.ID
+
+	// Here is one of the magicky parts: WaitForConverge. It should be used
+	// whenever you perform an operation changing cluster state, because those
+	// operations are _not_ synchronous. It takes a Context that provides a
+	// timeout, a polling period, and a function returning only an error. This
+	// function will be called each polling period, and if it returns nil, we
+	// will assume the test has succeeded. If the context times out, the
+	// polling will stop and and the error returned on the last poll of the
+	// function will be returned
 	ctx, _ := context.WithTimeout(testContext, 10*time.Second)
 	err = WaitForConverge(ctx, 2*time.Second, func() error {
-		_, _, err := cli.ServiceInspectWithRaw(ctx, resp.ID)
+		// in this case, we're just waiting for inspect to return no errors,
+		// which should happen almost instantly. More complicated checks will
+		// have more complicated functions
+		_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID)
 		if err != nil {
 			return err
 		}
@@ -56,7 +96,11 @@ func TestServicesCreate(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// clean up our service
+	// Clean up the test services. You should call this at the end of your
+	// test to clean up any services that belong to it. You MUST pass the name,
+	// or this call will clean up EVERYBODY's test services and cause
+	// everything to break. This function handles internally, under the hood,
+	// the uuid label-based isolation, so you don't have to worry about it.
 	CleanTestServices(testContext, cli, name)
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -62,6 +62,7 @@ func CannedServiceSpec(name string, replicas uint64, labels ...string) swarm.Ser
 		Annotations: swarm.Annotations{
 			Name: truncServiceName(name + UUID()),
 			Labels: map[string]string{
+				// the pre-mangled service name is a raw key-only label.
 				name:            "",
 				E2EServiceLabel: "true",
 				"uuid":          UUID(),
@@ -77,6 +78,7 @@ func CannedServiceSpec(name string, replicas uint64, labels ...string) swarm.Ser
 
 	// then, add labels
 	for _, label := range labels {
+		// TODO(dperny): allow labels in form key=value?
 		spec.Annotations.Labels[label] = ""
 	}
 


### PR DESCRIPTION
Fully documented TestServicesCreate to function as a prototypical test
that other developers can start from. Additionally, added a README to
the tests explaining some caveats of the testing "framework"

Depends on #25