### PR TITLE
Print the UUID for the tests before we start

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -44,6 +44,7 @@ func TestMain(m *testing.M) {
 		os.Exit(exit)
 	}()
 
+	fmt.Printf("Running tests with UUID %v\n", UUID())
 	// run the tests, save the exit
 	exit = m.Run()
 	// close the done channel to run cleanup


### PR DESCRIPTION
Prints the UUID before running the tests. Seems useful although TBQH I'm not sure of a specific use case.

Signed-off-by: Drew Erny <drew.erny@docker.com>