### PR TITLE
Use custom images

### DIFF
--- a/images/httptest/Dockerfile
+++ b/images/httptest/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:onbuild
+
+EXPOSE 80

--- a/images/httptest/httptest.go
+++ b/images/httptest/httptest.go
@@ -2,11 +2,32 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 )
 
 var hostname string
+
+func ProxyRoute(w http.ResponseWriter, req *http.Request) {
+	endpoint := req.URL.Path[len("/proxy/"):]
+	tr := &http.Transport{}
+	client := &http.Client{Transport: tr, Timeout: time.Duration(5 * time.Second)}
+	// TODO(dperny) handle custom port, possibly through querystring
+	resp, err := client.Get("http://" + endpoint)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(body)
+}
 
 func RootRoute(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, hostname)
@@ -16,5 +37,6 @@ func main() {
 	hostname, _ = os.Hostname()
 
 	http.HandleFunc("/", RootRoute)
+	http.HandleFunc("/proxy/", ProxyRoute)
 	http.ListenAndServe(":80", nil)
 }

--- a/images/httptest/httptest.go
+++ b/images/httptest/httptest.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+var hostname string
+
+func RootRoute(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, hostname)
+}
+
+func main() {
+	hostname, _ = os.Hostname()
+
+	http.HandleFunc("/", RootRoute)
+	http.ListenAndServe(":80", nil)
+}

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -34,7 +34,7 @@ func TestNetworkExternalLb(t *testing.T) {
 	replicas := 3
 	spec := CannedServiceSpec(name, uint64(replicas))
 	// use nginx
-	spec.TaskTemplate.ContainerSpec.Image = "dperny/docker-sample-nginx"
+	spec.TaskTemplate.ContainerSpec.Image = "dperny/httptest"
 	spec.TaskTemplate.ContainerSpec.Command = nil
 	// expose a port
 	spec.EndpointSpec = &swarm.EndpointSpec{


### PR DESCRIPTION
Adds a custom image for network testing. Image has a root route that returns its container name, and a `proxy` route that returns the response body of whatever the argument is. The latter is for an internal load balancing test that I am working on.