### PR TITLE
Add utility server and use self image for tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/docker/docker-e2e/tests
 
 COPY . /go/src/github.com/docker/docker-e2e/tests
 RUN go get -v -d -t ./...
+RUN go install -v ./util
 RUN go test -c
 
 CMD ["/go/src/github.com/docker/docker-e2e/tests/tests.test", "-test.v"]

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -56,7 +56,7 @@ func TestServicesCreate(t *testing.T) {
 	// up. In addition, CannedServiceSpec mangles the name and adds the uuid
 	// label that we rely on to isolate this particular instance of the tests
 	// from any other instance that may be running
-	serviceSpec := CannedServiceSpec(name, 3)
+	serviceSpec := CannedServiceSpec(cli, name, 3)
 
 	// Now, do an API call. Pass testContext, which will take care of the
 	// timeout for us.
@@ -113,7 +113,7 @@ func TestServicesScale(t *testing.T) {
 	assert.NoError(t, err, "could not create client")
 
 	// create a new service
-	serviceSpec := CannedServiceSpec(name, 1)
+	serviceSpec := CannedServiceSpec(cli, name, 1)
 	service, err := cli.ServiceCreate(testContext, serviceSpec, types.ServiceCreateOptions{})
 	assert.NoError(t, err, "error creating service")
 

--- a/tests/util/main.go
+++ b/tests/util/main.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+// TestServer is invoked for the `test-server` command
+func TestServer(c *cli.Context) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Not technically a response header, but we'll use it
+		w.Header().Set("Host", hostname)
+		w.WriteHeader(http.StatusOK)
+		msSleep := c.Int("request-time")
+		time.Sleep(time.Duration(msSleep) * time.Millisecond)
+		fmt.Fprintf(w, "OK")
+	})
+	http.HandleFunc("/fanout", func(w http.ResponseWriter, r *http.Request) {
+		// POST to /fanout with a new-line delimited list of URLs to request
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Host", hostname)
+		w.WriteHeader(http.StatusOK)
+		// Would it make sense to parallelize?
+		for _, target := range strings.Split(string(body), "\n") {
+			log.Debug("Req: %s -> %s", hostname, target)
+			// TODO - mTLS support?
+			resp, err := http.Get(target) // TODO Timeouts?
+			if err != nil {
+				fmt.Fprintf(w, "%s:ERROR:%s\n", target, err)
+			} else {
+				defer resp.Body.Close()
+				b, _ := ioutil.ReadAll(resp.Body)
+				fmt.Fprintf(w, "%s:%d:%s\n", target, resp.StatusCode, strings.TrimSpace(string(b)))
+			}
+		}
+	})
+	server := &http.Server{
+		Addr: c.String("listen-address"),
+	}
+
+	if c.Bool("tls") {
+		log.Info("Configuring TLS")
+
+		if c.Bool("client-auth") {
+			caCert, err := ioutil.ReadFile(c.String("ca"))
+			if err != nil {
+				return err
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+			server.TLSConfig = &tls.Config{
+				// ListenAndServeTLS will wire up the cert/key pairs automatically
+				ClientAuth: tls.RequireAndVerifyClientCert,
+				ClientCAs:  caCertPool,
+			}
+		}
+
+		log.Infof("Listening to HTTPS on %s", c.String("listen-address"))
+		return server.ListenAndServeTLS(c.String("cert"), c.String("key"))
+	}
+
+	log.Infof("Listening to HTTP on %s", c.String("listen-address"))
+	return server.ListenAndServe()
+
+}
+
+func TestTLSServer(c *cli.Context) error {
+	if c.String("cert") == "" || c.String("key") == "" {
+		log.Fatal("Unable to start ucp-proxy without TLS configuration")
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
+	server := &http.Server{
+		Addr: c.String("listen-address"),
+	}
+	log.Infof("Listening on %s", c.String("listen-address"))
+	log.Fatal(server.ListenAndServeTLS(c.String("cert"), c.String("key")))
+	return nil
+}
+
+// The `test-server` command returns a simple 200 OK at the / endpoint, meant to debug port connectivity
+var cmdTestServer = cli.Command{
+	Name:  "test-server",
+	Usage: "Returns 200 OK at /",
+	Description: `
+    `,
+	Action: TestServer,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "listen-address, l",
+			Usage: "Listen Address",
+			Value: ":80",
+		},
+		cli.StringFlag{
+			Name:   "ca",
+			Usage:  "Path to CA certificate",
+			EnvVar: "SSL_CA",
+			Value:  "/certs/ca.pem",
+		},
+		cli.StringFlag{
+			Name:   "cert",
+			Usage:  "Path to server certificate",
+			EnvVar: "SSL_CERT",
+			Value:  "/certs/cert.pem",
+		},
+		cli.StringFlag{
+			Name:   "key",
+			Usage:  "Path to certificate key",
+			EnvVar: "SSL_KEY",
+			Value:  "/certs/key.pem",
+		},
+		cli.BoolFlag{
+			Name:  "tls",
+			Usage: "Use TLS",
+		},
+		cli.BoolFlag{
+			Name:  "client-auth",
+			Usage: "Require client cert authentication for TLS",
+		},
+		cli.IntFlag{
+			Name:  "request-time, ms",
+			Usage: "Time to take in milliseconds before responding with OK",
+			Value: 0,
+		},
+	},
+}
+
+var cmdTestTLSServer = cli.Command{
+	Name:  "test-tls-server",
+	Usage: "Returns 200 OK at /",
+	Description: `
+    `,
+	Action: TestTLSServer,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "listen-address, l",
+			Usage: "Listen Address",
+			Value: ":2376",
+		},
+		cli.StringFlag{
+			Name:   "cert",
+			Usage:  "Path to server certificate",
+			EnvVar: "SSL_CERT",
+		},
+		cli.StringFlag{
+			Name:   "key",
+			Usage:  "Path to certificate key",
+			EnvVar: "SSL_KEY",
+		},
+	},
+}
+
+// Driver function
+func main() {
+	app := cli.NewApp()
+	app.Name = "E2E Utility"
+	app.Commands = []cli.Command{
+		cmdTestServer,
+		cmdTestTLSServer,
+	}
+	log.SetFormatter(&log.JSONFormatter{})
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This adds a very simple utility CLI with a server we can leverage for the
current tests, and expand over time to include additional utility logic.
It also revamps the tests to use the same image you're running instead
of depending on other external images.  If this is run in an environment
where ContainerList can't be relied upon, the test image can be specified
via env var, or fall back to a predifined image name.

Closes #39