### PR TITLE
Generate certs on the fly

### DIFF
--- a/testkit/machines/certs.go
+++ b/testkit/machines/certs.go
@@ -1,0 +1,106 @@
+package machines
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/initca"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+)
+
+// VerifyCA makes sure there's a CA present in the specified dir
+func VerifyCA(rootCADir string) error {
+	caFile := filepath.Join(rootCADir, "ca.pem")
+	if _, err := os.Stat(caFile); err == nil {
+		// If we can stat it, assume we're good
+		return nil
+	}
+	logrus.Debugf("Generating CA in %s", rootCADir)
+	// Quiet down the cfssl logging
+	log.Level = log.LevelWarning
+	req := csr.CertificateRequest{
+		CN:         "e2e ca",
+		KeyRequest: &csr.BasicKeyRequest{"ecdsa", 256},
+	}
+	caCert, _, key, err := initca.New(&req)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(rootCADir, "ca.pem"), caCert, 0644); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(rootCADir, "ca-key.pem"), key, 0600); err != nil {
+		return err
+	}
+	// Now generate a cert pair for local client use
+	_, clientCert, clientKey, err := GenerateNodeCerts(rootCADir, "client", []string{"127.0.0.1"})
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(rootCADir, "cert.pem"), clientCert, 0644); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(rootCADir, "key.pem"), clientKey, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GenerateNodeCerts will create a signed cert and key for the node
+// returns: ca, cert, key, error
+func GenerateNodeCerts(rootCADir, cn string, hosts []string) ([]byte, []byte, []byte, error) {
+	certDuration := time.Duration(10 * 365 * 24 * time.Hour)
+	s, err := local.NewSignerFromFile(
+		filepath.Join(rootCADir, "ca.pem"),
+		filepath.Join(rootCADir, "ca-key.pem"),
+		&config.Signing{
+			Default: &config.SigningProfile{
+				Usage: []string{
+					"signing",
+					"key encipherment",
+					"server auth",
+					"client auth",
+				},
+				Expiry:       certDuration,
+				ExpiryString: certDuration.String(),
+			},
+		})
+
+	if err != nil {
+		logrus.Debug("Failed to load signer")
+		return nil, nil, nil, err
+	}
+	req := &csr.CertificateRequest{
+		CN:         cn,
+		KeyRequest: &csr.BasicKeyRequest{"ecdsa", 256},
+		Hosts:      hosts,
+		Names:      []csr.Name{{}},
+	}
+	csr, key, err := csr.ParseRequest(req)
+	if err != nil {
+		logrus.Debug("Failed to parse csr")
+		return nil, nil, nil, err
+	}
+	cert, err := s.Sign(signer.SignRequest{
+		Request: string(csr),
+		Profile: "node",
+	})
+	if err != nil {
+		logrus.Debug("Sign failure")
+		return nil, nil, nil, err
+	}
+	ca, err := ioutil.ReadFile(filepath.Join(rootCADir, "ca.pem"))
+	if err != nil {
+		logrus.Debug("ca load")
+		return nil, nil, nil, err
+	}
+	return ca, cert, key, nil
+}

--- a/testkit/machines/provisioner.go
+++ b/testkit/machines/provisioner.go
@@ -106,6 +106,14 @@ func VerifyDockerEngine(m Machine, localCertDir string) error {
 	log.Debugf("Verifying or installing docker engine on %s", m.GetName())
 
 	resChan := make(chan error)
+	ip, err := m.GetIP()
+	if err != nil {
+		return err
+	}
+	internalIP, err := m.GetInternalIP()
+	if err != nil {
+		return err
+	}
 
 	go func(m Machine) {
 
@@ -151,18 +159,29 @@ func VerifyDockerEngine(m Machine, localCertDir string) error {
 				resChan <- fmt.Errorf("Failed to write daemon.json to %s: %s", m.GetName(), err)
 				return
 			}
-			for _, file := range []string{"ca.pem", "cert.pem", "key.pem"} {
-				localFile := filepath.Join(localCertDir, file)
-				fp, err := os.Open(localFile)
-				if err != nil {
-					resChan <- fmt.Errorf("Failed to open %s: %s", localFile, err)
-					return
-				}
-				err = m.WriteFile(filepath.Join("/etc/docker", file), fp)
-				if err != nil {
-					resChan <- fmt.Errorf("Failed to write %s to %s", file, m.GetName(), err)
-					return
-				}
+
+			ca, cert, key, err := GenerateNodeCerts(localCertDir, m.GetName(), []string{ip, internalIP, m.GetName()})
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write cert locally: %s", err)
+				return
+			}
+			cabuf := bytes.NewBuffer(ca)
+			err = m.WriteFile("/etc/docker/ca.pem", cabuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write ca.pem to %s: %s", m.GetName(), err)
+				return
+			}
+			certbuf := bytes.NewBuffer(cert)
+			err = m.WriteFile("/etc/docker/cert.pem", certbuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write cert.pem to %s: %s", m.GetName(), err)
+				return
+			}
+			keybuf := bytes.NewBuffer(key)
+			err = m.WriteFile("/etc/docker/key.pem", keybuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write key.pem to %s: %s", m.GetName(), err)
+				return
 			}
 
 			installCMD := EngineInstallCMD
@@ -268,7 +287,7 @@ func VerifyDockerEngine(m Machine, localCertDir string) error {
 
 	}(m)
 
-	timer := time.NewTimer(2 * time.Minute) // TODO - make configurable
+	timer := time.NewTimer(5 * time.Minute) // TODO - make configurable
 	select {
 	case res := <-resChan:
 		return res


### PR DESCRIPTION
Instead of sharing one set of certs, we can generate them on the fly
and inject node specific certs with proper IPs so TLS will pass verification.