### PR TITLE
Support windows only clusters

### DIFF
--- a/testkit/machines/certs.go
+++ b/testkit/machines/certs.go
@@ -57,6 +57,9 @@ func VerifyCA(rootCADir string) error {
 // GenerateNodeCerts will create a signed cert and key for the node
 // returns: ca, cert, key, error
 func GenerateNodeCerts(rootCADir, cn string, hosts []string) ([]byte, []byte, []byte, error) {
+	logrus.Debugf("Generating node cert for %s - %v", cn, hosts)
+	// Quiet down the cfssl logging
+	log.Level = log.LevelWarning
 	certDuration := time.Duration(10 * 365 * 24 * time.Hour)
 	s, err := local.NewSignerFromFile(
 		filepath.Join(rootCADir, "ca.pem"),

--- a/testkit/machines/provisioner.go
+++ b/testkit/machines/provisioner.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -90,13 +89,15 @@ func getServerVersion(m Machine) (string, error) {
 		return "", fmt.Errorf("Failed to get engine client: %s", err)
 	}
 	deadline := time.Now().Add(20 * time.Second) // How long should we wait?
+	var lastErr error
 	for time.Now().Before(deadline) {
 		version, err := dclient.ServerVersion(context.Background())
 		if err == nil {
 			return version.Version, nil
 		}
+		lastErr = err
 	}
-	return "", fmt.Errorf("Failed to get engine version")
+	return "", fmt.Errorf("Failed to get engine version before timing out: %s", lastErr)
 
 }
 
@@ -305,6 +306,15 @@ func VerifyDockerEngineWindows(m Machine, localCertDir string) error {
 
 	resChan := make(chan error, 1)
 
+	ip, err := m.GetIP()
+	if err != nil {
+		return err
+	}
+	internalIP, err := m.GetInternalIP()
+	if err != nil {
+		return err
+	}
+
 	go func(m Machine) {
 
 		// First check to see if docker is already installed
@@ -365,18 +375,28 @@ func VerifyDockerEngineWindows(m Machine, localCertDir string) error {
 				resChan <- fmt.Errorf("Failed to create daemoncerts dir %s: %s", m.GetName(), err, out)
 				return
 			}
-			for _, file := range []string{"ca.pem", "cert.pem", "key.pem"} {
-				localFile := filepath.Join(localCertDir, file)
-				fp, err := os.Open(localFile)
-				if err != nil {
-					resChan <- fmt.Errorf("Failed to open %s: %s", localFile, err)
-					return
-				}
-				err = m.WriteFile(fmt.Sprintf(`c:\ProgramData\docker\daemoncerts\%s`, file), fp)
-				if err != nil {
-					resChan <- fmt.Errorf("Failed to write %s to %s", file, m.GetName(), err)
-					return
-				}
+			ca, cert, key, err := GenerateNodeCerts(localCertDir, m.GetName(), []string{ip, internalIP, m.GetName()})
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write cert locally: %s", err)
+				return
+			}
+			cabuf := bytes.NewBuffer(ca)
+			err = m.WriteFile(`c:\ProgramData\docker\daemoncerts\ca.pem`, cabuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write ca.pem to %s: %s", m.GetName(), err)
+				return
+			}
+			certbuf := bytes.NewBuffer(cert)
+			err = m.WriteFile(`c:\ProgramData\docker\daemoncerts\cert.pem`, certbuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write cert.pem to %s: %s", m.GetName(), err)
+				return
+			}
+			keybuf := bytes.NewBuffer(key)
+			err = m.WriteFile(`c:\ProgramData\docker\daemoncerts\key.pem`, keybuf)
+			if err != nil {
+				resChan <- fmt.Errorf("Failed to write key.pem to %s: %s", m.GetName(), err)
+				return
 			}
 
 			out, err = m.MachineSSH("powershell dockerd.exe -H npipe:////./pipe/docker_engine -H 0.0.0.0:2376 --register-service")
@@ -417,6 +437,8 @@ func VerifyDockerEngineWindows(m Machine, localCertDir string) error {
 				if err == nil {
 					log.Infof("Succesfully installed engine %s on %s", ver, m.GetName())
 					break
+				} else {
+					log.Debugf("Error getting version: %s", err)
 				}
 				time.Sleep(500 * time.Millisecond)
 			}

--- a/testkit/machines/virsh_machine.go
+++ b/testkit/machines/virsh_machine.go
@@ -190,10 +190,6 @@ func NewVirshMachines(linuxCount, windowsCount int) ([]Machine, []Machine, error
 			m.tlsConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      caCertPool,
-
-				// NOTE:This is insecure, but the test VMs have a short-lifespan
-				InsecureSkipVerify: true, // We don't verify so we can recyle the same certs regardless of VM IP
-
 			}
 			linuxMachines = append(linuxMachines, m)
 		}
@@ -205,7 +201,7 @@ func NewVirshMachines(linuxCount, windowsCount int) ([]Machine, []Machine, error
 				CPUCount:    1,        // TODO - make configurable
 				Memory:      2048,     // TODO - make configurable
 				sshUser:     "docker", // TODO - make configurable
-				sshKeyPath:  filepath.Join(VirshDiskDir, "id_rsa"),
+				sshKeyPath:  sshKeyPath,
 				DiskType:    "ide",
 				NICType:     "e1000",
 			}
@@ -236,10 +232,6 @@ func NewVirshMachines(linuxCount, windowsCount int) ([]Machine, []Machine, error
 			m.tlsConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      caCertPool,
-
-				// NOTE:This is insecure, but the test VMs have a short-lifespan
-				InsecureSkipVerify: true, // We don't verify so we can recyle the same certs regardless of VM IP
-
 			}
 			windowsMachines = append(windowsMachines, m)
 		}
@@ -770,13 +762,16 @@ func (m *VirshMachine) writeLocalFile(localFilePath, remoteFilePath string) erro
 }
 
 func (m *VirshMachine) GetConnectionEnv() string {
-	return strings.Join([]string{
+	lines := []string{
 		fmt.Sprintf(`export DOCKER_HOST="tcp://%s:2376"`, m.ip),
 		fmt.Sprintf(`export DOCKER_CERT_PATH="%s"`, VirshDiskDir),
 		"export DOCKER_TLS_VERIFY=1",
 		fmt.Sprintf("# %s", m.MachineName),
-		fmt.Sprintf("# ssh -i %s %s@%s", m.sshKeyPath, m.sshUser, m.ip),
-		// TODO - once virsh generates valid SANs on derived certs add this
-		// "export DOCKER_TLS_VERIFY=1",
-	}, "\n")
+	}
+	if m.sshKeyPath != "" {
+		lines = append(lines, fmt.Sprintf("# ssh -i %s %s@%s", m.sshKeyPath, m.sshUser, m.ip))
+	} else {
+		lines = append(lines, fmt.Sprintf("# ssh %s@%s", m.sshUser, m.ip))
+	}
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
Fix a flawed assumption that we'll always have at least one linux node,
and cleans up a few minor glitches I missed in the prior cert/ssh key cleanup.