### PR TITLE
Rename Windows computers properly and don't share daemon.json between machines

### DIFF
--- a/testkit/machines/vbox_machine.go
+++ b/testkit/machines/vbox_machine.go
@@ -244,8 +244,8 @@ func NewVBoxMachines(linuxCount, windowsCount int) ([]Machine, []Machine, error)
 			wg.Add(1)
 			go func(m *VBoxMachine) {
 				var result error
-				out, err := m.machineSSH(
-					fmt.Sprintf(`powershell rename-computer -newname "%s" -restart`, m.GetName()), false)
+				out, err := m.MachineSSH(
+					fmt.Sprintf(`powershell rename-computer -force -newname "%s" -restart; exit`, m.GetName()))
 				if err != nil {
 					log.Warnf("Failed to set hostname to %s: %s: %s", m.GetName(), err, out)
 				}


### PR DESCRIPTION
I noticed that Windows machines were not getting properly renamed; it turns out
the reason why the rename-computer commands were hanging before is because they
were waiting for human input. I added -Force to fix this.

I also noticed Windows machines were broken because they don't support
selinux-enabled. We should be making sure we're not modifying the global
daemon.json files